### PR TITLE
Fixed bug with no emails set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,11 @@ resource "cloudflare_access_policy" "policy" {
   name           = "Allow Policy"
   precedence     = "1"
   decision       = "allow"
-  include {
-    email = var.allowed_emails
+  dynamic "include" {
+    for_each = var.allowed_emails
+    content {
+      email = [include.value]
+    }
   }
   include {
     github {


### PR DESCRIPTION
Fixed a bug where module would successfully plan but crash when applying an empty list of allowed emails.